### PR TITLE
Add workaround for github actions permissions issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Workaround bug in github actions
+        run: |
+          # see https://github.com/actions/runner-images/issues/6775
+          git config --global --add safe.directory /github/workspace
+
       - name: Release Gem
         uses: discourse/publish-rubygems-action@v2
         env:


### PR DESCRIPTION
The `publish` job is currently failing with this error when the `release` rake task is called:

```
+ exec rake release
Running gem release task...
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
rtlcss 0.2.0 built to pkg/rtlcss-0.2.0.gem.
rake aborted!
There are files that need to be committed first.
/usr/local/bundle/gems/bundler-2.4.7/lib/bundler/gem_helper.rb:168:in `guard_clean'
/usr/local/bundle/gems/bundler-2.4.7/lib/bundler/gem_helper.rb:72:in `block in install'
/usr/local/bundle/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
Tasks: TOP => release => release:guard_clean
(See full trace by running task with --trace)
```
(example failed run https://github.com/discourse/rtlcss/actions/runs/4182493506/jobs/7269406424)

However, this seems to be a problem with github actions per https://github.com/actions/runner-images/issues/6775 so let's add workaround until it's fixed upstream.